### PR TITLE
Use link instead of meta as tag for canonical link

### DIFF
--- a/app/views/seo_page_extender/_canonical_link.html.erb
+++ b/app/views/seo_page_extender/_canonical_link.html.erb
@@ -1,1 +1,1 @@
-<meta href="<%= canonical_link(@obj) %>" rel="canonical"/>
+<link href="<%= canonical_link(@obj) %>" rel="canonical"/>


### PR DESCRIPTION
Whereever (example [[1]](https://support.google.com/webmasters/answer/139066?hl=en#2)) I'm searching for `canonical link` I see that they are using `link` instead of `meta`.

Maybe we can adapt this to the `canonical_link` partial.

[1] [Use canonical URLs](https://support.google.com/webmasters/answer/139066?hl=en#2)