### PR TITLE
Maintenance / Fix attribute type

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ en:
         tc_creator: '<h3>Creator <small>Twitter name of the creator of this page e.g. @gertimon</small></h3>'
         tc_description: 'Description'
         tc_image: 'Image'
+        tc_image_alt: 'Image Description'
         tc_more_about: 'More about Twitter cards'
         tc_player_dimension: 'Dimension'
         tc_player_height: 'Height'

--- a/app/concerns/meta_data_extender.rb
+++ b/app/concerns/meta_data_extender.rb
@@ -1,16 +1,16 @@
 module MetaDataExtender
   def self.included(base)
+    base.attribute :meta_author,      :string
+    base.attribute :meta_copyright,   :string
     base.attribute :meta_description, :string
-    base.attribute :meta_keywords, :stringlist
-    base.attribute :meta_author, :string
-    base.attribute :meta_publisher, :string
-    base.attribute :meta_copyright, :string
+    base.attribute :meta_keywords,    :stringlist
+    base.attribute :meta_publisher,   :string
 
-    base.attribute :meta_canonical, :string
+    base.attribute :meta_canonical,   :string
 
-    base.attribute :meta_page_topic, :string
-    base.attribute :meta_page_type, :string
-    base.attribute :meta_audience, :multienum , values: ["all", "adult", "advanced", "artist", "business", "child", "college", "craft", "elementary", "elhi", "government", "grownup", "health", "high", "institution", "intermediate", "introductory", "law", "lawyer", "listeners", "military", "news", "older", "parent", "patient", "popular", "scholarly", "teacher", "tts", "viewers"]
-    base.attribute :meta_robots, :multienum, values: ["noindex", "nofollow", "noarchive", "nosnippet", "noimageindex", "notranslate", "noodp"]
+    base.attribute :meta_audience,    :multienum, values: %w[all adult advanced artist business child college craft elementary elhi government grownup health high institution intermediate introductory law lawyer listeners military news older parent patient popular scholarly teacher tts viewers]
+    base.attribute :meta_page_topic,  :string
+    base.attribute :meta_page_type,   :string
+    base.attribute :meta_robots,      :multienum, values: %w[noindex nofollow noarchive nosnippet noimageindex notranslate noodp]
   end
 end

--- a/app/concerns/open_graph_extender.rb
+++ b/app/concerns/open_graph_extender.rb
@@ -5,7 +5,7 @@ module OpenGraphExtender
     base.attribute :og_locale,               :string
     base.attribute :og_locale_alternate,     :stringlist
     base.attribute :og_title,                :string
-    base.attribute :og_type,                 :enum, values: ['website', 'article', 'book', 'profile', 'music.song', 'music.album', 'music.playlist', 'music.radiostation', 'video.movie', 'video.episode', 'video.tv_show', 'video.other']
+    base.attribute :og_type,                 :enum, values: ['website', 'article', 'blog', 'book', 'profile', 'music.song', 'music.album', 'music.playlist', 'music.radiostation', 'video.movie', 'video.episode', 'video.tv_show', 'video.other']
 
     base.attribute :og_audio,                :reference
     base.attribute :og_image,                :reference

--- a/app/concerns/open_graph_extender.rb
+++ b/app/concerns/open_graph_extender.rb
@@ -1,48 +1,48 @@
 module OpenGraphExtender
   def self.included(base)
-    base.attribute :og_title, :string
-    base.attribute :og_type, :enum, values: ['website','article','book','profile','music.song','music.album','music.playlist','music.radiostation','video.movie','video.episode','video.tv_show','video.other']
-    base.attribute :og_locale, :string
-    base.attribute :og_locale_alternate, :stringlist
-    base.attribute :og_description, :string
-    base.attribute :og_determiner, :string
+    base.attribute :og_description,          :string
+    base.attribute :og_determiner,           :string
+    base.attribute :og_locale,               :string
+    base.attribute :og_locale_alternate,     :stringlist
+    base.attribute :og_title,                :string
+    base.attribute :og_type,                 :enum, values: ['website', 'article', 'book', 'profile', 'music.song', 'music.album', 'music.playlist', 'music.radiostation', 'video.movie', 'video.episode', 'video.tv_show', 'video.other']
 
-    base.attribute :og_image, :reference
-    base.attribute :og_audio, :reference
-    base.attribute :og_video, :reference
+    base.attribute :og_audio,                :reference
+    base.attribute :og_image,                :reference
+    base.attribute :og_video,                :reference
 
-    base.attribute :article_published_time, :date
+    base.attribute :article_author,          :stringlist
     base.attribute :article_expiration_time, :date
-    base.attribute :article_author, :stringlist
-    base.attribute :article_section, :string
-    base.attribute :article_tag, :stringlist
+    base.attribute :article_published_time,  :date
+    base.attribute :article_section,         :string
+    base.attribute :article_tag,             :stringlist
 
-    base.attribute :book_author, :stringlist
-    base.attribute :book_isbn, :string
-    base.attribute :book_release_date, :date
-    base.attribute :book_tag, :stringlist
+    base.attribute :book_author,             :stringlist
+    base.attribute :book_isbn,               :string
+    base.attribute :book_release_date,       :date
+    base.attribute :book_tag,                :stringlist
 
-    base.attribute :profile_first_name, :string
-    base.attribute :profile_last_name, :string
-    base.attribute :profile_username, :string
-    base.attribute :profile_gender, :enum, values: ['male','female']
+    base.attribute :profile_first_name,      :string
+    base.attribute :profile_gender,          :enum, values: %w[male female]
+    base.attribute :profile_last_name,       :string
+    base.attribute :profile_username,        :string
 
     # Video Attributes
-    base.attribute :video_actor, :stringlist
-    base.attribute :video_actor_role, :string
-    base.attribute :video_director, :stringlist
-    base.attribute :video_writer, :stringlist
-    base.attribute :video_duration, :string
-    base.attribute :video_release_date, :date
-    base.attribute :video_tag, :stringlist
-    base.attribute :video_series, :string
+    base.attribute :video_actor,             :stringlist
+    base.attribute :video_actor_role,        :string
+    base.attribute :video_director,          :stringlist
+    base.attribute :video_duration,          :string
+    base.attribute :video_release_date,      :date
+    base.attribute :video_series,            :string
+    base.attribute :video_tag,               :stringlist
+    base.attribute :video_writer,            :stringlist
 
     # Music Attributes
-    base.attribute :music_duration, :string
-    base.attribute :music_musician, :stringlist
-    base.attribute :music_album, :stringlist
-    base.attribute :music_creator, :string
-    base.attribute :music_song, :stringlist
+    base.attribute :music_album,             :stringlist
+    base.attribute :music_creator,           :string
+    base.attribute :music_duration,          :string
+    base.attribute :music_musician,          :stringlist
+    base.attribute :music_song,              :stringlist
 
     def image_width
       self.og_image.meta_data[:width]

--- a/app/concerns/sitemap_extender.rb
+++ b/app/concerns/sitemap_extender.rb
@@ -1,6 +1,6 @@
 module SitemapExtender
   def self.included(base)
-    base.attribute :sitemap_frequency, :enum, values: ["always", "hourly", "daily", "weekly", "monthly", "yearly", "never"]
-    base.attribute :sitemap_priority, :enum, values: ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "1.0"]
+    base.attribute :sitemap_frequency, :enum, values: %w[always hourly daily weekly monthly yearly never]
+    base.attribute :sitemap_priority,  :enum, values: ['0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1.0']
   end
 end

--- a/app/concerns/twitter_cards_extender.rb
+++ b/app/concerns/twitter_cards_extender.rb
@@ -1,33 +1,33 @@
 module TwitterCardsExtender
   def self.included(base)
     # General Attributes
-    base.attribute :tc_card, :enum, values: ["summary", "summary_large_image", "app", "player"]
-    base.attribute :tc_creator, :string
-    base.attribute :tc_site, :string
-    base.attribute :tc_title, :string
-    base.attribute :tc_description, :string
+    base.attribute :tc_card,                       :enum, values: %w[summary summary_large_image app player]
+    base.attribute :tc_creator,                    :string
+    base.attribute :tc_description,                :string
+    base.attribute :tc_site,                       :string
+    base.attribute :tc_title,                      :string
 
     # Image and Gallery
-    base.attribute :tc_image, :reference
-    base.attribute :tc_image_alt, :reference
+    base.attribute :tc_image,                      :reference
+    base.attribute :tc_image_alt,                  :reference
 
     # For type app
-    base.attribute :tc_app_name_iphone, :string
-    base.attribute :tc_app_name_ipad, :string
-    base.attribute :tc_app_name_googleplay, :string
-    base.attribute :tc_app_id_iphone, :string
-    base.attribute :tc_app_id_ipad, :string
-    base.attribute :tc_app_id_googleplay, :string
-    base.attribute :tc_app_url_iphone, :string
-    base.attribute :tc_app_url_ipad, :string
-    base.attribute :tc_app_url_googleplay, :string
-    base.attribute :tc_app_country, :string
+    base.attribute :tc_app_country,                :string
+    base.attribute :tc_app_id_googleplay,          :string
+    base.attribute :tc_app_id_ipad,                :string
+    base.attribute :tc_app_id_iphone,              :string
+    base.attribute :tc_app_name_googleplay,        :string
+    base.attribute :tc_app_name_ipad,              :string
+    base.attribute :tc_app_name_iphone,            :string
+    base.attribute :tc_app_url_googleplay,         :string
+    base.attribute :tc_app_url_ipad,               :string
+    base.attribute :tc_app_url_iphone,             :string
 
     # For type Player
-    base.attribute :tc_player, :string
-    base.attribute :tc_player_width, :string
-    base.attribute :tc_player_height, :string
-    base.attribute :tc_player_stream, :string
+    base.attribute :tc_player,                     :string
+    base.attribute :tc_player_height,              :string
+    base.attribute :tc_player_stream,              :string
     base.attribute :tc_player_stream_content_type, :string
+    base.attribute :tc_player_width,               :string
   end
 end

--- a/app/concerns/twitter_cards_extender.rb
+++ b/app/concerns/twitter_cards_extender.rb
@@ -9,7 +9,7 @@ module TwitterCardsExtender
 
     # Image and Gallery
     base.attribute :tc_image,                      :reference
-    base.attribute :tc_image_alt,                  :reference
+    base.attribute :tc_image_alt,                  :string
 
     # For type app
     base.attribute :tc_app_country,                :string

--- a/app/views/seo_page_extender/_twitter_cards.html.erb
+++ b/app/views/seo_page_extender/_twitter_cards.html.erb
@@ -4,6 +4,7 @@
 <%= render "seo_page_extender/meta_attribute", attribute: "tc_title", name: "twitter:title" -%>
 <%= render "seo_page_extender/meta_attribute", attribute: "tc_description", name: "twitter:description" -%>
 <%= render "seo_page_extender/meta_attribute", attribute: "tc_image", name: "twitter:image" -%>
+<%= render "seo_page_extender/meta_attribute", attribute: "tc_image_alt", name: "twitter:image:alt" -%>
 <%= render "seo_page_extender/meta_attribute", attribute: "tc_app_name_iphone", name: "twitter:app:name:iphone" -%>
 <%= render "seo_page_extender/meta_attribute", attribute: "tc_app_id_iphone", name: "twitter:app:id:iphone" -%>
 <%= render "seo_page_extender/meta_attribute", attribute: "tc_app_url_iphone", name: "twitter:url:iphone" -%>

--- a/app/views/seo_page_extender/_twitter_cards_details.html.erb
+++ b/app/views/seo_page_extender/_twitter_cards_details.html.erb
@@ -30,6 +30,10 @@
     <%= scrivito_details_for t('scrivito_seo_page_extender.details.twitter_cards_extender.tc_image', default: 'Image') do %>
       <%= scrivito_tag(:div, obj, :tc_image) %>
     <% end %>
+
+    <%= scrivito_details_for t('scrivito_seo_page_extender.details.twitter_cards_extender.tc_image_alt', default: 'Image Description') do %>
+      <%= scrivito_tag(:div, obj, :tc_image_alt) %>
+    <% end %>
   </div>
 
   <div class="tab-panel" id="edit-twitter-card-app">


### PR DESCRIPTION
This PR consists of three commits:

1. some rubocop corrections, alignment and alphabetical sorting of the attributes inside the concerns (feel free to call me Monk ;) )
2. change the attribute type of `tc_image_alt` to `string`, add i18n key, render this attribute in the source and make it editable
3. add a new type for OpenGraph: 'blog'